### PR TITLE
docs: refactor CLAUDE.md with progressive disclosure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,130 +1,21 @@
-# Claude Code Guidelines
+# The Holga Project
 
-## Architecture
+Browser-based Holga-like photo filter app (Vite + TypeScript).
 
-**Always use factory functions, never classes** for components:
+## Build
 
-```typescript
-export default function MyComponent(
-  pubsub: PubSub,
-  dependency: SomeType
-): MyComponentInterface {
-  let state = initialState;
+- `npm run build` — type-check + test + vite build
+- `npm run type-check` — `tsc --noEmit`
 
-  function privateHelper() { /* ... */ }
+## Key Conventions
 
-  return { init, cleanup };
-}
-```
+- **Factory functions only** — never classes for components
+- **State machine** for all state transitions — never mutate state directly
+- **`logError`** from `@/types/errors` — never `console.error`
 
-### Component Lifecycle
+## Docs
 
-All components must implement `init()` and `cleanup()`. Components must be safe to call `cleanup()` multiple times.
-
-### AbortController for DOM Event Listeners
-
-Always use AbortController — never manual `removeEventListener`:
-
-```typescript
-let eventController: AbortController | null = null;
-
-function addEvents(): void {
-  if (eventController) {
-    eventController.abort();
-  }
-
-  eventController = new AbortController();
-  const { signal } = eventController;
-
-  element.addEventListener("click", handler, { signal });
-}
-
-function cleanup(): void {
-  if (eventController) {
-    eventController.abort();
-    eventController = null;
-  }
-}
-```
-
-### PubSub for Component Communication
-
-Use PubSub for decoupled communication. Subscribe in `init()`, unsubscribe in `cleanup()`.
-
----
-
-## State Management
-
-Use the state machine for all state transitions — never mutate state directly. Subscribe to `STATE_CHANGED` via PubSub for reactive handling. All transitions must be defined in the machine; invalid transitions throw errors intentionally.
-
----
-
-## TypeScript
-
-- Default exports OK for components, named exports for utilities/constants
-- Explicit types for public APIs
-
----
-
-## Comments
-
-Do not add comments for self-evident code. Only comment to explain **why**, not what:
-
-```typescript
-// BAD
-// Check if the image is valid
-const isValidImage = validateImageFile(file);
-
-// GOOD - explains WHY
-// Safari requires explicit clearRect before drawing to prevent visual artifacts
-contextObject.clearRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
-```
-
----
-
-## Error Handling
-
-- Use custom error classes: `FileUploadError.validation(...)`, `CanvasError.contextCreation()`
-- Use `logError` from `@/types/errors` — never `console.error` directly
-
----
-
-## Testing
-
-- Use Vitest. All new components/utilities must have `.test.ts` files
-- Every component must test: init works, cleanup works, multiple cleanup calls safe, listeners removed on cleanup, subscriptions cleaned up
-
----
-
-## Code Organization
-
-```
-src/
-├── components/       # UI components
-├── state/           # State management (machine, store, pubsub)
-├── lib/             # Third-party or complex algorithms
-├── utils/           # Pure utility functions
-├── config/          # Configuration constants
-├── types/           # TypeScript types and error classes
-└── main.ts          # Application factory
-```
-
----
-
-## Performance
-
-Always `clearRect` before `drawImage` on canvas — Safari requires this to prevent visual artifacts.
-
----
-
-## Commit Conventions
-
-Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
-
-```
-<type>: <description>
-
-<optional body>
-```
-
-Types: `feat`, `fix`, `refactor`, `chore`, `test`, `docs`
+- [Architecture](docs/claude/architecture.md)
+- [TypeScript & Error Handling](docs/claude/typescript.md)
+- [Testing](docs/claude/testing.md)
+- [Git](docs/claude/git.md)

--- a/docs/claude/architecture.md
+++ b/docs/claude/architecture.md
@@ -1,0 +1,78 @@
+# Architecture
+
+## Factory Functions
+
+Always use factory functions, never classes:
+
+```typescript
+export default function MyComponent(
+  pubsub: PubSub,
+  dependency: SomeType
+): MyComponentInterface {
+  let state = initialState;
+
+  function privateHelper() { /* ... */ }
+
+  return { init, cleanup };
+}
+```
+
+## Component Lifecycle
+
+All components must implement `init()` and `cleanup()`. `cleanup()` must be safe to call multiple times.
+
+## AbortController for DOM Events
+
+Always use AbortController — never manual `removeEventListener`:
+
+```typescript
+let eventController: AbortController | null = null;
+
+function addEvents(): void {
+  if (eventController) {
+    eventController.abort();
+  }
+
+  eventController = new AbortController();
+  const { signal } = eventController;
+
+  element.addEventListener("click", handler, { signal });
+}
+
+function cleanup(): void {
+  if (eventController) {
+    eventController.abort();
+    eventController = null;
+  }
+}
+```
+
+## PubSub
+
+Use PubSub for decoupled component communication. Subscribe in `init()`, unsubscribe in `cleanup()`.
+
+## State Management
+
+Use the state machine for all transitions — never mutate state directly. Subscribe to `STATE_CHANGED` via PubSub for reactive handling. Invalid transitions throw intentionally.
+
+## Performance
+
+Always `clearRect` before `drawImage` on canvas:
+
+```typescript
+// Safari requires explicit clearRect before drawing to prevent visual artifacts
+contextObject.clearRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
+```
+
+## Code Organization
+
+```
+src/
+├── components/       # UI components
+├── state/           # State management (machine, store, pubsub)
+├── lib/             # Third-party or complex algorithms
+├── utils/           # Pure utility functions
+├── config/          # Configuration constants
+├── types/           # TypeScript types and error classes
+└── main.ts          # Application factory
+```

--- a/docs/claude/git.md
+++ b/docs/claude/git.md
@@ -1,0 +1,11 @@
+# Git
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):
+
+```
+<type>: <description>
+
+<optional body>
+```
+
+Types: `feat`, `fix`, `refactor`, `chore`, `test`, `docs`

--- a/docs/claude/testing.md
+++ b/docs/claude/testing.md
@@ -1,0 +1,11 @@
+# Testing
+
+Use Vitest. All new components/utilities must have `.test.ts` files.
+
+Every component must test:
+
+- `init()` works
+- `cleanup()` works
+- Multiple `cleanup()` calls are safe
+- Listeners removed on cleanup
+- Subscriptions cleaned up on cleanup

--- a/docs/claude/typescript.md
+++ b/docs/claude/typescript.md
@@ -1,0 +1,18 @@
+# TypeScript & Error Handling
+
+## Exports
+
+- Default exports for components
+- Named exports for utilities/constants
+- Explicit types for public APIs
+
+## Error Handling
+
+Use custom error classes:
+
+```typescript
+FileUploadError.validation(...)
+CanvasError.contextCreation()
+```
+
+Use `logError` from `@/types/errors` — never `console.error` directly.


### PR DESCRIPTION
## Summary

- Slims root `CLAUDE.md` to essentials: project description, build commands, 3 key conventions + links
- Moves detailed conventions into `docs/claude/{architecture,typescript,testing,git}.md`
- Deletes redundant `Comments` section (general principle agents already know)
- Merges `Performance` note into `architecture.md` with inline code context

No contradictions found in the original file.

**Flagged as redundant/obvious and removed:**
- `## Comments` — "explain why not what" is a general coding principle
- `## Code Organization` from root (moved to `architecture.md`)

Closes #31

## Test plan

- [ ] Verify links in root `CLAUDE.md` resolve to correct sub-files
- [ ] Confirm all original instructions are present across the new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)